### PR TITLE
Ruby dependency updates

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -84,7 +84,7 @@ jobs:
     #     source: ./
     #     destination: ./_site
     - name: 🔻💎🔻 Set up Ruby
-      uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+      uses: ruby/setup-ruby@50ba3386b050ad5b97a41fcb81240cbee1d1821f # v1.188.0
       with:
         ruby-version: ${{ env.development_ruby_version }}
         rubygems: ${{ env.development_rubygems_version }}

--- a/.github/workflows/ruby-build.yaml
+++ b/.github/workflows/ruby-build.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🔻💎🔻 Set up Ruby
-      uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+      uses: ruby/setup-ruby@50ba3386b050ad5b97a41fcb81240cbee1d1821f # v1.188.0
       with:
         ruby-version: '2.7'
         bundler-cache: true
@@ -112,7 +112,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🔻💎🔻 Set up Ruby
-      uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+      uses: ruby/setup-ruby@50ba3386b050ad5b97a41fcb81240cbee1d1821f # v1.188.0
       with:
         ruby-version: '2.7'
         bundler-cache: true
@@ -149,7 +149,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🔻💎🔻 Set up Ruby
-      uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+      uses: ruby/setup-ruby@50ba3386b050ad5b97a41fcb81240cbee1d1821f # v1.188.0
       with:
         ruby-version: '2.7'
         bundler-cache: true

--- a/.github/workflows/ruby-test.yaml
+++ b/.github/workflows/ruby-test.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🔻💎🔻 Set up Ruby
-      uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+      uses: ruby/setup-ruby@50ba3386b050ad5b97a41fcb81240cbee1d1821f # v1.188.0
       with:
         ruby-version: '2.7'
         bundler-cache: true
@@ -52,12 +52,12 @@ jobs:
       fail-fast: false
       matrix:
         version: ['2.7.0', '3.0', '3.1']
-        os: [ubuntu-latest, macOS-latest, windows-latest] #  # < maybe.
+        os: [ubuntu-latest, macOS-12, windows-latest] #  # < maybe.
     steps:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🔻💎🔻 Set up Ruby ${{ matrix.version }}
-      uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+      uses: ruby/setup-ruby@50ba3386b050ad5b97a41fcb81240cbee1d1821f # v1.188.0
       with:
         ruby-version: ${{ matrix.version }}
         bundler-cache: true
@@ -84,7 +84,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🔻💎🔻 Set up Ruby
-      uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+      uses: ruby/setup-ruby@50ba3386b050ad5b97a41fcb81240cbee1d1821f # v1.188.0
       with:
         ruby-version: '2.7'
         bundler-cache: true

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -7,8 +7,8 @@ gemspec
 
 gem "rake", "~> 13.2"
 
-gem "rdoc", "~> 6.6"
+gem "rdoc", "~> 6.7"
 
 gem "rspec", "~> 3.13"
 
-gem "rubocop", "~> 1.63"
+gem "rubocop", "~> 1.65"

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -10,19 +10,20 @@ GEM
     diff-lcs (1.5.1)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    parallel (1.24.0)
-    parser (3.3.0.5)
+    parallel (1.25.1)
+    parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
     psych (5.1.2)
       stringio
-    racc (1.7.3)
+    racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.6.3.1)
+    rdoc (6.7.0)
       psych (>= 4.0.0)
-    regexp_parser (2.9.0)
-    rexml (3.2.6)
+    regexp_parser (2.9.2)
+    rexml (3.3.2)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -36,21 +37,22 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.63.2)
+    rubocop (1.65.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
+      regexp_parser (>= 2.4, < 3.0)
       rexml (>= 3.2.5, < 4.0)
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    stringio (3.1.0)
+    stringio (3.1.1)
+    strscan (3.1.0)
     unicode-display_width (2.5.0)
 
 PLATFORMS
@@ -60,9 +62,9 @@ PLATFORMS
 DEPENDENCIES
   collatz!
   rake (~> 13.2)
-  rdoc (~> 6.6)
+  rdoc (~> 6.7)
   rspec (~> 3.13)
-  rubocop (~> 1.63)
+  rubocop (~> 1.65)
 
 BUNDLED WITH
    2.3.21


### PR DESCRIPTION
A bunch of ruby dependabot PRs with errors are sitting around, so try to clear them up with one that just updates a bunch.
NOTE: This sets macos runner to os version 12 instead of latest, as macos-latest (14 atm) drops support for ruby 2.7