### PR TITLE
GitHub Workflow action version updates: upload and download artifact

### DIFF
--- a/.github/workflows/R-build.yaml
+++ b/.github/workflows/R-build.yaml
@@ -85,7 +85,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Tarball
         path: R
@@ -130,7 +130,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Docs
         path: R/docs

--- a/.github/workflows/R-build.yaml
+++ b/.github/workflows/R-build.yaml
@@ -70,7 +70,7 @@ jobs:
     - name: 🧱 Build and Check
       run: make cran_check
     - name: 🆙 Upload tarball
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Tarball
         path: R/collatz_*.tar.gz
@@ -115,7 +115,7 @@ jobs:
     - name: 📄 Docs Generation
       run: make docs
     - name: 🆙 Upload docs
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Docs
         path: R/docs/

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -240,7 +240,7 @@ jobs:
         version: ${{ env.development_<language>_version }}
         arch: 'x64'
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Package
         path: <language>/.demo
@@ -372,7 +372,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     # - name: 🆒 Download dists
-    #   uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+    #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
     #   with:
     #     name: some-artefacts
     #     path: <language>/some-artefacts
@@ -392,7 +392,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     # - name: 🆒 Download dists
-    #   uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+    #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
     #   with:
     #     name: some-artefacts
     #     path: <language>/some-artefacts

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -215,7 +215,7 @@ jobs:
     - name: 🧱 Build
       run: make build
     - name: 🆙 Upload dists
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Package
         path: <language>/some-artefacts/path-to-one-file.pkg
@@ -357,7 +357,7 @@ jobs:
       run: make <make-environment-dependencies>
     # Some step that uses `make build`
     # - name: 🆙 Upload dists
-    #   uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+    #   uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
     #   with:
     #     name: some-artefacts
     #     path: <language>/some-artefacts/

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -73,7 +73,7 @@ jobs:
       run: make build
     # Some step that uses `make build`
     - name: 🆙 Upload dists
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Collatz
         path: go/collatz/collatz

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -50,6 +50,20 @@ jobs:
       matrix:
         go-version: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18']
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+        - go-version: '1.13'
+          os: macOS-latest
+        - go-version: '1.14'
+          os: macOS-latest
+        - go-version: '1.15'
+          os: macOS-latest
+        include:
+        - go-version: '1.13'
+          os: macOS-12
+        - go-version: '1.14'
+          os: macOS-12
+        - go-version: '1.15'
+          os: macOS-12
     steps:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/java-build.yaml
+++ b/.github/workflows/java-build.yaml
@@ -75,7 +75,7 @@ jobs:
     - name: 🏺 Build jar and source
       run: make build_noninteractive
     - name: 🆙 Upload jar
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Package
         path: java/target/*.jar

--- a/.github/workflows/java-build.yaml
+++ b/.github/workflows/java-build.yaml
@@ -90,7 +90,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Package
         path: java/target

--- a/.github/workflows/javascript-build.yaml
+++ b/.github/workflows/javascript-build.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Package
         path: javascript
@@ -111,7 +111,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Package
         path: javascript/
@@ -137,7 +137,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Package
         path: javascript/

--- a/.github/workflows/javascript-build.yaml
+++ b/.github/workflows/javascript-build.yaml
@@ -76,7 +76,7 @@ jobs:
     - name: 🧱 Build
       run: make build
     - name: 🆙 Upload dists
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Package
         path: javascript/skenvy-collatz-*.tgz

--- a/.github/workflows/javascript-test.yaml
+++ b/.github/workflows/javascript-test.yaml
@@ -121,7 +121,7 @@ jobs:
       with:
         node-version-file: 'javascript/.nvmrc'
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Package
         path: javascript/.demo

--- a/.github/workflows/javascript-test.yaml
+++ b/.github/workflows/javascript-test.yaml
@@ -97,7 +97,7 @@ jobs:
     - name: 🧱 Build
       run: make build
     - name: 🆙 Upload dists
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Package
         path: javascript/skenvy-collatz-*.tgz

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: built-dists
         path: python/dist
@@ -116,7 +116,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: built-dists
         path: python/dist

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -76,7 +76,7 @@ jobs:
     - name: 🎡 Build wheel and source
       run: make build
     - name: 🆙 Upload dists
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: built-dists
         path: python/dist/

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -115,7 +115,7 @@ jobs:
       with:
         python-version: ${{ env.development_python_version }}
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Package
         path: python/.demo

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: 🧱 Build
       run: make build
     - name: 🆙 Upload dists
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Package
         path: python/dist/collatz-*-none-any.whl

--- a/.github/workflows/ruby-build.yaml
+++ b/.github/workflows/ruby-build.yaml
@@ -75,7 +75,7 @@ jobs:
     - name: 💎 Build gem
       run: make build
     - name: 🆙 Upload dists
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: Gem
         path: ruby/pkg/collatz-*.gem

--- a/.github/workflows/ruby-build.yaml
+++ b/.github/workflows/ruby-build.yaml
@@ -90,7 +90,7 @@ jobs:
     - name: 🏁 Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Gem
         path: ruby/pkg
@@ -119,7 +119,7 @@ jobs:
     - name: 🔑 Keycutter for GitHub
       run: make setup_github
     - name: 🆒 Download dists
-      uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: Gem
         path: ruby/pkg


### PR DESCRIPTION
A bunch of GH workflow dependabot PRs with errors are sitting around, so try to clear them up with one that just updates a bunch.